### PR TITLE
Fix default config by replacing API url with new domain

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -1,3 +1,3 @@
-API: https://idonthavespotify.donado.co/api/search?v=1
+API: https://idonthavespotify.sjdonado.com/api/search?v=1
 services:  # any of spotify, apple, deezer, soundcloud, tidal, youtube
   - spotify


### PR DESCRIPTION
Hello! Thank you for making this maubot plugin, I've been experimenting with matrix and setup maubot recently and have been going down the list of available plugins. The original API url in the config now redirects to a new domain, meaning that by default the bot will not work

`https://idonthavespotify.donado.co` now redirects to `https://idonthavespotify.sjdonado.com`

Replacing this URL fixes the bot with the default config.